### PR TITLE
Setting compiler.libcxx explicitly for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build
 *.pyc
+/_build
+conanbuildinfo.cmake
+conaninfo.txt
+/gtest-1.7.0

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,10 +18,6 @@ class GTestConan(ConanFile):
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
     
-    def config(self):
-        if self.settings.os == "Macos":
-            self.settings.compiler.libcxx = "libc++"
-
     def source(self):
         zip_name = "gtest-%s.zip" % self.version
         url = "https://googletest.googlecode.com/files/%s" % zip_name

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,10 @@ class GTestConan(ConanFile):
     exports = "CMakeLists.txt"
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
+    
+    def config(self):
+        if self.settings.os == "Macos":
+            self.settings.compiler.libcxx = "libc++"
 
     def source(self):
         zip_name = "gtest-%s.zip" % self.version

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,12 +17,6 @@ class GTestConan(ConanFile):
     exports = "CMakeLists.txt"
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
-    
-    def config(self):
-        try: # Try catch can be removed when conan 0.8 is released
-            del self.settings.compiler.libcxx
-        except:
-            pass
 
     def source(self):
         zip_name = "gtest-%s.zip" % self.version

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,12 @@ class GTestConan(ConanFile):
     exports = "CMakeLists.txt"
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
+    
+    def config(self):
+        try: # Try catch can be removed when conan 0.8 is released
+            del self.settings.compiler.libcxx
+        except:
+            pass
 
     def source(self):
         zip_name = "gtest-%s.zip" % self.version

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 PROJECT(MyHello)
 cmake_minimum_required(VERSION 3.0)
 
-include(conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 
 ADD_EXECUTABLE(mytest test.cpp)

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -9,10 +9,16 @@ class DefaultNameConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     generators = "cmake"
     requires = "gtest/1.7.0@lasote/stable"
+    
+    def config(self):
+        try: # Try catch can be removed when conan 0.8 is released
+            del self.settings.compiler.libcxx
+        except:
+            pass
 
     def build(self):
         cmake = CMake(self.settings)
-        self.run('cmake . %s' % cmake.command_line)
+        self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake --build . %s" % cmake.build_config)
 
     def imports(self):

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -9,10 +9,6 @@ class DefaultNameConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     generators = "cmake"
     requires = "gtest/1.7.0@lasote/stable"
-    
-    def config(self):
-        if self.settings.os == "Macos":
-            self.settings.compiler.libcxx = "libc++"
         
     def build(self):
         cmake = CMake(self.settings)

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -11,11 +11,9 @@ class DefaultNameConan(ConanFile):
     requires = "gtest/1.7.0@lasote/stable"
     
     def config(self):
-        try: # Try catch can be removed when conan 0.8 is released
-            del self.settings.compiler.libcxx
-        except:
-            pass
-
+        if self.settings.os == "Macos":
+            self.settings.compiler.libcxx = "libc++"
+        
     def build(self):
         cmake = CMake(self.settings)
         self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))


### PR DESCRIPTION
So, setting compiler.libcxx to libc++ worked. I have added a condition to only set it on OSX. I have run conan build and conan test on the modified package on Windows and Debian too and I get no errors. Please let me know if you think the package is ok now.

By the way, on OSX, even after running pip install --upgrade conan, conan --version still outputs 0.9.3. Maybe conan does not get upgraded properly there? (on Debian it reports the latest version) 

One little question I have is, even though setting compiler.libcxx to libc++ worked, why did completely removing compiler.libcxx also not produce any errors when running conan build and conan test on OSX? I am trying to understand conan better so this is just for my information...