### PR TITLE
Added option for including symbols (PDBs) from MSVC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you handle multiple dependencies in your project is better to add a *conanfil
 
     [options]
     gtest:shared=true # false
+    gtest:include_pdbs=false # MSVC - include debug symbols
     
     [generators]
     txt

--- a/build.py
+++ b/build.py
@@ -4,5 +4,21 @@ from conan.packager import ConanMultiPackager
 if __name__ == "__main__":
     builder = ConanMultiPackager()
     builder.add_common_builds(shared_option_name="gtest:shared", pure_c=False)
+    filtered_builds = []
+    for settings, options in builder.builds:
+        if settings["compiler"] == "Visual Studio":
+            pdbOptions = options.copy()
+            noPdbOptions = options.copy()
+            
+            pdbOptions.update({"gtest:include_pdbs": "True"})
+            noPdbOptions.update({"gtest:include_pdbs": "False"})
+            
+            filtered_builds.append([settings, options])
+            filtered_builds.append([settings, pdbOptions])
+            filtered_builds.append([settings, noPdbOptions])
+        else:
+            filtered_builds.append([settings, options])
+    
+    builder.builds = filtered_builds
     builder.run()
 

--- a/build.py
+++ b/build.py
@@ -8,17 +8,11 @@ if __name__ == "__main__":
     for settings, options in builder.builds:
         if settings["compiler"] == "Visual Studio":
             pdbOptions = options.copy()
-            noPdbOptions = options.copy()
-            
             pdbOptions.update({"gtest:include_pdbs": "True"})
-            noPdbOptions.update({"gtest:include_pdbs": "False"})
-            
-            filtered_builds.append([settings, options])
             filtered_builds.append([settings, pdbOptions])
-            filtered_builds.append([settings, noPdbOptions])
-        else:
-            filtered_builds.append([settings, options])
-    
+        
+        filtered_builds.append([settings, options])
+
     builder.builds = filtered_builds
     builder.run()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,6 +18,10 @@ class GTestConan(ConanFile):
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
     
+    def config_options(self):
+        if self.settings.compiler != "Visual Studio":
+            del self.options.include_pdbs
+    
     def source(self):
         zip_name = "release-%s.zip" % self.version
         url = "https://github.com/google/googletest/archive/%s" % zip_name
@@ -48,8 +52,8 @@ class GTestConan(ConanFile):
         self.copy(pattern="*.so*", dst="lib", src=".", keep_path=False)
         self.copy(pattern="*.dylib*", dst="lib", src=".", keep_path=False)      
         
-        # Debug files
-        if self.options.include_pdbs:
+        # Copying debug symbols
+        if self.settings.compiler == "Visual Studio" and self.options.include_pdbs:
             self.copy(pattern="*.pdb", dst="lib", src=".", keep_path=False)
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,8 +12,8 @@ class GTestConan(ConanFile):
     ZIP_FOLDER_NAME = "googletest-release-%s" % version
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False]}
-    default_options = "shared=True"
+    options = {"shared": [True, False], "include_pdbs": [True, False]}
+    default_options = "shared=True", "include_pdbs=False"
     exports = "CMakeLists.txt"
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
@@ -47,6 +47,10 @@ class GTestConan(ConanFile):
         self.copy(pattern="*.dll", dst="bin", src=".", keep_path=False)
         self.copy(pattern="*.so*", dst="lib", src=".", keep_path=False)
         self.copy(pattern="*.dylib*", dst="lib", src=".", keep_path=False)      
+        
+        # Debug files
+        if self.options.include_pdbs:
+            self.copy(pattern="*.pdb", dst="lib", src=".", keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = ['gtest', 'gtest_main']


### PR DESCRIPTION
As mentioned in #9:

I'm building a project that uses the gtest package and I would like to avoid LNK4099 (missing gtest.pdb) warnings when building with MSVC.

This PR has an implementation that's worked for me, and its a fairly minor change. Maybe the option could be named better, but you know: 

> There are only two hard things in Computer Science: cache invalidation and naming things.
> -- Phil Karlton