### PR TITLE
enable a setting for cygwin-invoked MSVC compiler to not error out.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,12 +8,12 @@ from conans import CMake
 
 class GTestConan(ConanFile):
     name = "gtest"
-    version = "1.7.0"
+    version = "1.8.0"
     ZIP_FOLDER_NAME = "googletest-release-%s" % version
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "include_pdbs": [True, False]}
-    default_options = "shared=True", "include_pdbs=False"
+    options = {"shared": [True, False], "include_pdbs": [True, False], "cygwin_msvc": [True, False]}
+    default_options = "shared=True", "include_pdbs=False", "cygwin_msvc=False"
     exports = "CMakeLists.txt"
     url="http://github.com/lasote/conan-gtest"
     license="https://github.com/google/googletest/blob/master/googletest/LICENSE"
@@ -34,7 +34,8 @@ class GTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-        if self.settings.os == "Windows":
+        msdos_shell = (self.settings.os == "Windows") and (self.options.cygwin_msvc == False)
+        if msdos_shell:
             self.run("IF not exist _build mkdir _build")
         else:
             self.run("mkdir _build")
@@ -46,7 +47,8 @@ class GTestConan(ConanFile):
 
     def package(self):
         # Copying headers
-        self.copy(pattern="*.h", dst="include", src="%s/include" % self.ZIP_FOLDER_NAME, keep_path=True)
+        self.copy(pattern="*.h", dst="include", src="%s/googletest/include" % self.ZIP_FOLDER_NAME, keep_path=True)
+        self.copy(pattern="*.h", dst="include", src="%s/googlemock/include" % self.ZIP_FOLDER_NAME, keep_path=True)
 
         # Copying static and dynamic libs
         self.copy(pattern="*.a", dst="lib", src=".", keep_path=False)
@@ -60,7 +62,7 @@ class GTestConan(ConanFile):
             self.copy(pattern="*.pdb", dst="lib", src=".", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ['gtest', 'gtest_main']
+        self.cpp_info.libs = ['gtest', 'gtest_main', 'gmock', 'gmock_main']
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         


### PR DESCRIPTION
Without this edit, invoking conan from cygwin shell gives an error like ' IF command not found '. With this fix, building from Visual Studio 2015 compiler invoked from cygwin succeeds when you set the cygwin_msvc option to "True" for a project. 