### PR TITLE
Support VS2017 by switching to C++11 impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,9 @@ PROJECT(conangtest)
 cmake_minimum_required(VERSION 2.8)
 include(conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
+
+if (MSVC_VERSION GREATER_EQUAL 1910)
+   add_definitions(-DGTEST_LANG_CXX11=1)
+endif()
+
 add_subdirectory("googletest-release-1.8.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,3 +84,6 @@ class GTestConan(ConanFile):
 
         if self.options.shared:
             self.cpp_info.defines.append("GTEST_LINKED_AS_SHARED_LIBRARY=1")
+
+        if self.settings.compiler == "Visual Studio" and self.settings.compiler.version >= 15:
+            self.cpp_info.defines.append("GTEST_LANG_CXX11=1")


### PR DESCRIPTION
Gtest 1.8 still uses tr1 on VS15 (2017) even if C++11 is fully supported.
This makes the package incompatible with /std:c++latest (and other strict conformance mode).
Pending a fix & release of GTest, I believe this is an acceptable workaround.