### PR TITLE
Add patch number to minimum CMake version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 PROJECT(conangtest)
 
 MESSAGE("Conan Gtest Wrapped CMake")
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 include(conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 


### PR DESCRIPTION
conanbuildinfo.cmake uses add_compile_options, which was only added in CMake 2.8.12.