### PR TITLE
fix tr1 tuple deprecation errors in vs2017 15.5

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,6 +43,8 @@ class GTestConan(ConanFile):
                 cmake.definitions["BUILD_SHARED_LIBS"] = "1"
             if self.options.fpic:
                 cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = "ON"
+            if float(str(self.settings.compiler.version)) >= 15 and self.settings.compiler == "Visual Studio":
+                cmake.definitions["CMAKE_CXX_FLAGS"] = "-DGTEST_LANG_CXX11=1 -DGTEST_HAS_TR1_TUPLE=0"
 
             cmake.definitions["BUILD_GTEST"] = "ON" if self.options.no_gmock else "OFF"
             cmake.definitions["BUILD_GMOCK"] = "OFF" if self.options.no_gmock else "ON"
@@ -91,3 +93,4 @@ class GTestConan(ConanFile):
 
         if float(str(self.settings.compiler.version)) >= 15 and self.settings.compiler == "Visual Studio":
             self.cpp_info.defines.append("GTEST_LANG_CXX11=1")
+            self.cpp_info.defines.append("GTEST_HAS_TR1_TUPLE=0")


### PR DESCRIPTION
Fixes errors while building with Visual Studio 2017 v15.5.2:
`warning C4996: 'std::tr1': warning STL4002: The non-Standard std::tr1 namespace and TR1-only machinery are deprecated and will be REMOVED. You can define _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING to acknowledge that you have received this warning.`

 `error C2220: warning treated as error - no 'object' file generated`