### PR TITLE
Remove -WX flag in msvc builds because it will break builds with msvc 15.5

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,6 +43,13 @@ class GTestConan(ConanFile):
                 cmake.definitions["BUILD_SHARED_LIBS"] = "1"
             if self.options.fpic:
                 cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = "ON"
+            if self.settings.compiler == "Visual Studio":
+                tools.replace_in_file("../%s/googletest/cmake/internal_utils.cmake" % self.ZIP_FOLDER_NAME,
+                    # The -WX flag will treat all warnings as error, which breaks builds with Visual Studio 15.5 (2017).
+                    # Removing it in msvc build is generally a good idea
+                    "-WX",
+                    ""
+                )
 
             cmake.definitions["BUILD_GTEST"] = "ON" if self.options.no_gmock else "OFF"
             cmake.definitions["BUILD_GMOCK"] = "OFF" if self.options.no_gmock else "ON"


### PR DESCRIPTION
Remove `-WX` flag (treat all warnings as error) in `build` because msvc 15.5 produce new warnings which will be treated as error thanks to the `-WX` flag and so it breaks the build. I would remove these flag generally in msvc build because other people reported that the builds will break regulary with `-WX`, because MS add more warnings in each version of msvc.

See issue from offical [googletest repo](https://github.com/google/googletest/issues/1373)

Greetings  
Tonka